### PR TITLE
correct the frameWidth and frameHeight

### DIFF
--- a/Source/Tools/SpritePacker/SpritePacker.cpp
+++ b/Source/Tools/SpritePacker/SpritePacker.cpp
@@ -73,7 +73,9 @@ public:
         offsetX(0),
         offsetY(0),
         frameX(0),
-        frameY(0)
+        frameY(0),
+        frameWidth(0),
+        frameHeight(0)
     {
     }
 


### PR DESCRIPTION
If someone uses SpritePacker without option -trim, it use incorrect values of frameWidth and frameHeight sometimes, like as 
```
<SubTexture name="2" x="0" y="0" width="64" height="64" frameWidth="1768300646" frameHeight="1696621932" offsetX="0" offsetY="0" />
```